### PR TITLE
make sharedPreferences + etc

### DIFF
--- a/app/src/main/java/com/example/ruok_workers/InfoRevisionFragment.kt
+++ b/app/src/main/java/com/example/ruok_workers/InfoRevisionFragment.kt
@@ -1,25 +1,29 @@
 package com.example.ruok_workers
 
+import android.app.AlertDialog
+import android.app.Dialog
+import android.content.Context
 import android.content.Intent
+import android.content.SharedPreferences
 import android.os.Bundle
 import androidx.fragment.app.Fragment
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.widget.ArrayAdapter
 import android.widget.Button
+import android.widget.EditText
+import android.widget.ListView
 
-// TODO: Rename parameter arguments, choose names that match
-// the fragment initialization parameters, e.g. ARG_ITEM_NUMBER
+
 private const val ARG_PARAM1 = "param1"
 private const val ARG_PARAM2 = "param2"
 
-/**
- * A simple [Fragment] subclass.
- * Use the [InfoRevisionFragment.newInstance] factory method to
- * create an instance of this fragment.
- */
 class InfoRevisionFragment : Fragment() {
-    // TODO: Rename and change types of parameters
+
+    private val organizations = listOf("Lover Center", "Vision Center", "Apple Center")
+    private val dummyIds = listOf("user1", "admin", "testuser") // 더미 데이터
+
     private var param1: String? = null
     private var param2: String? = null
 
@@ -29,39 +33,115 @@ class InfoRevisionFragment : Fragment() {
             param1 = it.getString(ARG_PARAM1)
             param2 = it.getString(ARG_PARAM2)
         }
+
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
+        val sharedPreferences = requireActivity().getSharedPreferences("user_prefs", Context.MODE_PRIVATE)
+        val userId = sharedPreferences.getString("registered_id", "")
+        val userPassword = sharedPreferences.getString("registered_password", "")
+        val userName = sharedPreferences.getString("user_name", "")
+        val userBirth = sharedPreferences.getString("user_birth", "")
+        val userOrganization = sharedPreferences.getString("user_organization", "")
+
+        view.findViewById<EditText>(R.id.input_id).setText(userId)
+        view.findViewById<EditText>(R.id.input_password).setText(userPassword)
+        view.findViewById<EditText>(R.id.input_workerName).setText(userName)
+        view.findViewById<EditText>(R.id.input_workerBirth).setText(userBirth)
+        view.findViewById<EditText>(R.id.input_organizations).setText(userOrganization)
+
         val modifyButton = view.findViewById<Button>(R.id.modify_button)
         modifyButton.setOnClickListener {
+            val editedUserId = view.findViewById<EditText>(R.id.input_id).text.toString()
+            val editedUserPassword = view.findViewById<EditText>(R.id.input_password).text.toString()
+            val editedUserName = view.findViewById<EditText>(R.id.input_workerName).text.toString()
+            val editedUserBirth = view.findViewById<EditText>(R.id.input_workerBirth).text.toString()
+            val editedUserOrganization = view.findViewById<EditText>(R.id.input_organizations).text.toString()
+
+            val editor: SharedPreferences.Editor = sharedPreferences.edit()
+            editor.putString("registered_id", editedUserId)
+            editor.putString("registered_password", editedUserPassword)
+            editor.putString("user_name", editedUserName)
+            editor.putString("user_birth", editedUserBirth)
+            editor.putString("user_organization", editedUserOrganization)
+            editor.apply()
+        }
+
+        // "소속 찾기" 버튼 클릭 이벤트 핸들러 추가
+        view.findViewById<Button>(R.id.find_organizations).setOnClickListener {
+            showSearchDialog()
+        }
+
+        //아이디 중복여부 검사
+        val checkIdDuplicateButton = view.findViewById<Button>(R.id.check_id_duplicate)
+        checkIdDuplicateButton.setOnClickListener {
+            checkIdDuplicate()
+        }
+
+
+        val modifyConfirmButton = view.findViewById<Button>(R.id.modify_button)
+        modifyConfirmButton.setOnClickListener {
             // 수정하기 버튼을 클릭하면 DashboardActivity로 이동
             val intent = Intent(activity, DashboardActivity::class.java)
             startActivity(intent)
             activity?.finish() // 회원정보 수정 화면을 종료하여 뒤로 가기 버튼을 눌렀을 때 다시 회원정보 수정 화면이 나타나지 않도록 함
         }
-    }
 
+    }
 
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View? {
-        // Inflate the layout for this fragment
         return inflater.inflate(R.layout.fragment_info_revision, container, false)
     }
 
+    fun checkIdDuplicate() {
+        val inputId = view?.findViewById<EditText>(R.id.input_id)?.text.toString()
+        if (dummyIds.contains(inputId)) {
+            showAlertDialog("중복된 아이디", "다른 아이디를 선택해주세요")
+        } else {
+            showAlertDialog("사용 가능", "사용 가능한 아이디입니다")
+        }
+    }
+
+    fun showAlertDialog(title: String, message: String) {
+        AlertDialog.Builder(requireContext())
+            .setTitle(title)
+            .setMessage(message)
+            .setPositiveButton("확인", null)
+            .show()
+    }
+
+    // "소속 찾기" 다이얼로그 표시 함수
+    private fun showSearchDialog() {
+        val dialog = Dialog(requireContext())
+        dialog.setContentView(R.layout.dialog_search_organizations)
+
+        val searchInput = dialog.findViewById<EditText>(R.id.search_input)
+        val searchButton = dialog.findViewById<Button>(R.id.search_button)
+        val searchResults = dialog.findViewById<ListView>(R.id.search_results)
+
+        searchButton.setOnClickListener {
+            val query = searchInput.text.toString()
+            val filteredOrganizations = organizations.filter { it.contains(query, ignoreCase = true) }
+            val adapter = ArrayAdapter(requireContext(), android.R.layout.simple_list_item_1, filteredOrganizations)
+            searchResults.adapter = adapter
+        }
+
+        searchResults.setOnItemClickListener { _, _, position, _ ->
+            val selectedOrganization = searchResults.getItemAtPosition(position) as String
+            val inputOrganizations = view?.findViewById<EditText>(R.id.input_organizations)
+            inputOrganizations?.setText(selectedOrganization)
+            dialog.dismiss()
+        }
+
+        dialog.show()
+    }
+
     companion object {
-        /**
-         * Use this factory method to create a new instance of
-         * this fragment using the provided parameters.
-         *
-         * @param param1 Parameter 1.
-         * @param param2 Parameter 2.
-         * @return A new instance of fragment InfoRevisionFragment.
-         */
-        // TODO: Rename and change types and number of parameters
         @JvmStatic
         fun newInstance(param1: String, param2: String) =
             InfoRevisionFragment().apply {

--- a/app/src/main/java/com/example/ruok_workers/LoginActivity.kt
+++ b/app/src/main/java/com/example/ruok_workers/LoginActivity.kt
@@ -1,8 +1,11 @@
 package com.example.ruok_workers
 
+import android.content.Context
 import android.content.Intent
 import android.os.Bundle
 import android.widget.Button
+import android.widget.EditText
+import android.widget.Toast
 import androidx.activity.enableEdgeToEdge
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.view.ViewCompat
@@ -21,10 +24,21 @@ class LoginActivity : AppCompatActivity() {
 
         val loginButton = findViewById<Button>(R.id.button)
         loginButton.setOnClickListener {
-            // 로그인 버튼을 클릭하면 DashboardActivity로 이동
-            val intent = Intent(this, DashboardActivity::class.java)
-            startActivity(intent)
-            finish() // 로그인 화면을 종료하여 뒤로 가기 버튼을 눌렀을 때 다시 로그인 화면이 나타나지 않도록 함
+            val inputId = findViewById<EditText>(R.id.input_id).text.toString()
+            val inputPassword = findViewById<EditText>(R.id.input_password).text.toString()
+
+            val sharedPreferences = getSharedPreferences("user_prefs", Context.MODE_PRIVATE)
+            val registeredId = sharedPreferences.getString("registered_id", null)
+            val registeredPassword = sharedPreferences.getString("registered_password", null)
+
+            if (inputId == registeredId && inputPassword == registeredPassword) {
+                // 로그인 성공 시 DashboardActivity로 이동
+                val intent = Intent(this, DashboardActivity::class.java)
+                startActivity(intent)
+                finish() // 로그인 화면을 종료하여 뒤로 가기 버튼을 눌렀을 때 다시 로그인 화면이 나타나지 않도록 함
+            } else {
+                Toast.makeText(this, "아이디 또는 비밀번호가 잘못되었습니다", Toast.LENGTH_SHORT).show()
+            }
         }
     }
 }

--- a/app/src/main/java/com/example/ruok_workers/RegisterActivity.kt
+++ b/app/src/main/java/com/example/ruok_workers/RegisterActivity.kt
@@ -2,12 +2,14 @@ package com.example.ruok_workers
 
 import android.app.AlertDialog
 import android.app.Dialog
+import android.content.Context
 import android.content.Intent
 import android.os.Bundle
+import android.widget.ArrayAdapter
 import android.widget.Button
 import android.widget.EditText
 import android.widget.ListView
-import android.widget.ArrayAdapter
+import android.widget.Toast
 import androidx.activity.enableEdgeToEdge
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.view.ViewCompat
@@ -31,9 +33,38 @@ class RegisterActivity : AppCompatActivity() {
 
         val signUpButton = findViewById<Button>(R.id.signUp_button2)
         signUpButton.setOnClickListener {
-            val intent = Intent(this, MainActivity::class.java)
-            startActivity(intent)
+            val inputId = findViewById<EditText>(R.id.input_id).text.toString()
+            val inputPassword = findViewById<EditText>(R.id.input_password).text.toString()
+            val inputCheckPassword = findViewById<EditText>(R.id.input_check_password).text.toString()
+            val inputName = findViewById<EditText>(R.id.input_workerName).text.toString() // 사용자 이름 입력
+            val inputBirth = findViewById<EditText>(R.id.input_workerBirth).text.toString() // 사용자 생년월일 입력
+            val inputOrganization = findViewById<EditText>(R.id.input_organizations).text.toString() // 사용자 소속 입력
+
+            if (inputId.isBlank() || inputPassword.isBlank() || inputCheckPassword.isBlank() || inputName.isBlank() || inputBirth.isBlank() || inputOrganization.isBlank()) {
+                Toast.makeText(this, "모든 필드를 입력해주세요", Toast.LENGTH_SHORT).show()
+            } else if (inputPassword != inputCheckPassword) {
+                Toast.makeText(this, "비밀번호가 일치하지 않습니다", Toast.LENGTH_SHORT).show()
+            } else if (dummyIds.contains(inputId)) {
+                Toast.makeText(this, "중복된 아이디입니다", Toast.LENGTH_SHORT).show()
+            } else {
+                // 회원 정보를 SharedPreferences에 저장
+                val sharedPreferences = getSharedPreferences("user_prefs", Context.MODE_PRIVATE)
+                with(sharedPreferences.edit()) {
+                    putString("registered_id", inputId)
+                    putString("registered_password", inputPassword)
+                    putString("user_name", inputName) // 사용자 이름 저장
+                    putString("user_birth", inputBirth) // 사용자 생년월일 저장
+                    putString("user_organization", inputOrganization) // 사용자 소속 저장
+                    apply()
+                }
+                Toast.makeText(this, "회원가입 성공", Toast.LENGTH_SHORT).show()
+
+                val intent = Intent(this, LoginActivity::class.java)
+                startActivity(intent)
+                finish()
+            }
         }
+
 
         val findOrganizationsButton = findViewById<Button>(R.id.find_organizations)
         findOrganizationsButton.setOnClickListener {
@@ -46,7 +77,7 @@ class RegisterActivity : AppCompatActivity() {
         }
     }
 
-    private fun showSearchDialog() {
+    fun showSearchDialog() {
         val dialog = Dialog(this)
         dialog.setContentView(R.layout.dialog_search_organizations)
 
@@ -71,7 +102,7 @@ class RegisterActivity : AppCompatActivity() {
         dialog.show()
     }
 
-    private fun checkIdDuplicate() {
+    fun checkIdDuplicate() {
         val inputId = findViewById<EditText>(R.id.input_id).text.toString()
         if (dummyIds.contains(inputId)) {
             showAlertDialog("중복된 아이디", "다른 아이디를 선택해주세요")
@@ -80,7 +111,7 @@ class RegisterActivity : AppCompatActivity() {
         }
     }
 
-    private fun showAlertDialog(title: String, message: String) {
+    fun showAlertDialog(title: String, message: String) {
         AlertDialog.Builder(this)
             .setTitle(title)
             .setMessage(message)

--- a/app/src/main/res/layout/fragment_info_revision.xml
+++ b/app/src/main/res/layout/fragment_info_revision.xml
@@ -11,7 +11,8 @@
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:orientation="vertical"
-        android:gravity="center">
+        android:gravity="center"
+        tools:ignore="ExtraText">
 
         <EditText
             android:id="@+id/input_id"
@@ -23,6 +24,22 @@
             app:layout_constraintHorizontal_bias="0.168"
             app:layout_constraintStart_toEndOf="@+id/id"
             app:layout_constraintTop_toTopOf="@+id/id" />
+
+        <Button
+            android:id="@+id/check_id_duplicate"
+            android:layout_width="120dp"
+            android:layout_height="48dp"
+            android:layout_marginStart="16dp"
+            android:layout_marginTop="30dp"
+            android:layout_marginEnd="16dp"
+            android:layout_marginBottom="16dp"
+            android:backgroundTint="#F27406"
+            android:text="중복 확인"
+            android:textStyle="bold"
+            app:layout_constraintBottom_toTopOf="@+id/input_password"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toEndOf="@+id/input_id"
+            app:layout_constraintTop_toBottomOf="@+id/worker_profileImage" />
 
         <EditText
             android:id="@+id/input_password"
@@ -86,7 +103,7 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_marginStart="20dp"
-            android:layout_marginTop="140dp"
+            android:layout_marginTop="120dp"
             android:layout_marginEnd="16dp"
             android:layout_marginBottom="30dp"
             app:layout_constraintBottom_toTopOf="@+id/input_id"
@@ -175,15 +192,33 @@
 
         <EditText
             android:id="@+id/input_organizations"
-            android:layout_width="170dp"
+            android:layout_width="wrap_content"
             android:layout_height="49dp"
-            android:layout_marginTop="-20dp"
-            android:layout_marginEnd="16dp"
+            android:layout_marginStart="16dp"
+            android:layout_marginTop="16dp"
+            android:layout_marginEnd="32dp"
             android:hint="소속을 입력하세요"
             app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintHorizontal_bias="0.3"
+            app:layout_constraintHorizontal_bias="0.0"
             app:layout_constraintStart_toEndOf="@+id/organizations"
-            app:layout_constraintTop_toTopOf="@+id/organizations" />
+            app:layout_constraintTop_toBottomOf="@+id/input_check_password" />
+
+        <Button
+            android:id="@+id/find_organizations"
+            android:layout_width="120dp"
+            android:layout_height="48dp"
+            android:layout_marginStart="8dp"
+            android:layout_marginTop="8dp"
+            android:layout_marginEnd="16dp"
+            android:layout_marginBottom="4dp"
+            android:backgroundTint="#F27406"
+            android:text="소속 찾기"
+            android:textStyle="bold"
+            app:layout_constraintBottom_toTopOf="@+id/modify_button"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toEndOf="@+id/input_organizations"
+            app:layout_constraintTop_toBottomOf="@+id/input_check_password"
+            tools:ignore="MissingConstraints" />
 
     </androidx.constraintlayout.widget.ConstraintLayout>
 


### PR DESCRIPTION
1. 회원가입 정보 공유를 위한 일방향 스트림 코드 추가 (양방향 구현은 Backend의 영역으로, 구현하지 않음)
2. '회원가입 - 로그인 - 회원정보 수정' 까지 정보 공유하는 sharedPreferences 로직 구현
3. 2번 로직 기반 데이터 중복여부 검사 로직 구현 (by overriding)
4. 회원가입부터 회원 정보 수정까지 사용되는 모든 메서드 속성 변경: private --> public or protected
5. 회원정보 수정 페이지에서 '소속 변경' + '변경된 아이디 중복검사' 기능 추가 구현
6. 기타 UI/UX 및 레이아웃 수정