### PR TITLE
상담내역 수정 PhotoRevisionFragment.kt 기존 데이터 적용 구현

### DIFF
--- a/app/src/main/java/com/example/ruok_workers/PhotoRevisionFragment.kt
+++ b/app/src/main/java/com/example/ruok_workers/PhotoRevisionFragment.kt
@@ -2,13 +2,17 @@ package com.example.ruok_workers
 
 import android.Manifest
 import android.app.Activity
+import android.content.Context
 import android.content.Intent
 import android.content.pm.PackageManager
+import android.database.Cursor
 import android.database.sqlite.SQLiteDatabase
 import android.graphics.Bitmap
+import android.graphics.BitmapFactory
 import android.net.Uri
 import android.os.Bundle
 import android.provider.MediaStore
+import android.util.Log
 import androidx.fragment.app.Fragment
 import android.view.LayoutInflater
 import android.view.View
@@ -19,6 +23,12 @@ import androidx.core.app.ActivityCompat
 import androidx.core.content.ContextCompat
 import com.example.ruok_workers.databinding.FragmentPhotoAddBinding
 import com.example.ruok_workers.databinding.FragmentPhotoRevisionBinding
+import java.io.File
+import java.io.InputStream
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+import java.util.Vector
 
 class PhotoRevisionFragment : Fragment() {
     lateinit var binding : FragmentPhotoRevisionBinding
@@ -30,25 +40,73 @@ class PhotoRevisionFragment : Fragment() {
     lateinit var dbManager: DBManager
     lateinit var sqlitedb: SQLiteDatabase
 
+    lateinit var item: ConsultationItem
+    var c_num = -1
+
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View? {
         binding = FragmentPhotoRevisionBinding.inflate(inflater, container, false)
 
-        //데이터베이스 연동
+        //전달된 가져오기
+        item = arguments?.getParcelable<ConsultationItem>("consultation_item")!!
+        val hasConsultation = arguments?.getInt("hasConsultation")!!
+        c_num = arguments?.getInt("c_num", 0)!!
+
+        //데이터베이스 연동 및 기존 데이터 적용
+        val photoList = Vector<String>()
         dbManager = DBManager(requireContext(), "RUOKsample", null, 1)
+        sqlitedb = dbManager.readableDatabase
+        var cursor: Cursor
+        val sql = "SELECT p_filename FROM photo WHERE c_num = ?;"
+        cursor = sqlitedb.rawQuery(sql, arrayOf(c_num.toString()))
+        while (cursor.moveToNext()) {
+            photoList.add(cursor.getString(cursor.getColumnIndexOrThrow("p_filename")))
+        }
+        cursor.close()
+        sqlitedb.close()
         dbManager.close()
+
+        //기존 사진 ivPhotoRevision 넣기(마지막 사진 하나밖에 안 들어감): 사진이 내부저장소에 저장된 경우
+//        for (i in 0 until photoList.size) {
+//            val fileName: String = photoList.get(i)
+//            val filePath = requireContext().filesDir.absolutePath + "/" + fileName
+//
+//            val imgFile = File(filePath)
+//            if(imgFile.exists()) {
+//                val bitmap = BitmapFactory.decodeFile(imgFile.absolutePath)
+//                binding.ivPhotoRevision.setImageBitmap(bitmap)
+//            }
+//        }
+
+        ////기존 사진 ivPhotoRevision 넣기(마지막 사진 하나밖에 안 들어감): 사진이 drawable에 저장된 경우
+        for (i in 0 until photoList.size) {
+            var resId = resources.getIdentifier(photoList.get(i).substringBefore('.'), "drawable", requireContext().packageName)
+            binding.ivPhotoRevision.setImageResource(resId)
+        }
 
         //btnPhotoRevisionBack클릭시 PhotoRevisionFragment에서 RevisionFragment로 이동
         binding.btnPhotoRevisionBack.setOnClickListener {
             val DashboardActivity = activity as DashboardActivity
-            DashboardActivity.setFragment(RevisionFragment())
+            val revisionFragment = RevisionFragment()
+            val bundle = Bundle()
+            bundle.putInt("hasConsultation", hasConsultation)
+            bundle.putInt("c_num", c_num)
+            bundle.putParcelable("consultation_item", item)
+            revisionFragment.arguments = bundle
+            DashboardActivity.setFragment(revisionFragment)
         }
         //btnPhotoRevisionNext클릭시 PhotoRevisionFragment에서 HomelessListFragment로 이동
         binding.btnPhotoRevisionNext.setOnClickListener {
             val DashboardActivity = activity as DashboardActivity
-            DashboardActivity.setFragment(HomelessRevisionFragment())
+            val homelessRevisionFragment = HomelessRevisionFragment()
+            val bundle = Bundle()
+            bundle.putInt("hasConsultation", hasConsultation)
+            bundle.putInt("c_num", c_num)
+            bundle.putParcelable("consultation_item", item)
+            homelessRevisionFragment.arguments = bundle
+            DashboardActivity.setFragment(homelessRevisionFragment)
         }
         //btnPhotoRevisionCamera클릭시 카메라열고 찍은 사진 ivPhotoRevision에 넣기
         binding.btnPhotoRevisionCamera.setOnClickListener {
@@ -114,11 +172,41 @@ class PhotoRevisionFragment : Fragment() {
         super.onActivityResult(requestCode, resultCode, data)
         if (resultCode == Activity.RESULT_OK && requestCode == 1000){
             val imageBitmap = data?.extras?.get("data") as Bitmap
+
+            //사진 내부 저장소에 저장하기
+            val currentTime = System.currentTimeMillis()
+            val sdf = SimpleDateFormat("yyyyMMddHHmmssSSS", Locale.getDefault())
+            val filename = c_num.toString() + "_" + sdf.format(Date(currentTime))
+            saveImageToInternalStorage(imageBitmap, filename)
+            item.filename = arrayOf(filename)
+
             binding.ivPhotoRevision.setImageBitmap(imageBitmap)
         }
     }
     //선택한 사진 ivPhotoRevision에 넣기
     fun setGallery(uri: Uri?){
         binding.ivPhotoRevision.setImageURI(uri)
+        val inputStream: InputStream? = requireContext().contentResolver.openInputStream(uri!!)
+        val imageBitmap = BitmapFactory.decodeStream(inputStream) ?: throw IllegalArgumentException(
+            "이미지를 로드할 수 없습니다."
+        )
+
+        //사진 내부 저장소에 저장하기
+        val currentTime = System.currentTimeMillis()
+        val sdf = SimpleDateFormat("yyyyMMddHHmmssSSS", Locale.getDefault())
+        val filename = c_num.toString() + "_" + sdf.format(Date(currentTime))
+        saveImageToInternalStorage(imageBitmap, filename)
+        item.filename = arrayOf(filename)
+    }
+
+    //사진 내부 저장소에 저장하기
+    private fun saveImageToInternalStorage(bitmap: Bitmap, filename: String) {
+        try {
+            val fileOutputStream = requireContext().openFileOutput(filename, Context.MODE_PRIVATE)
+            bitmap.compress(Bitmap.CompressFormat.JPEG, 100, fileOutputStream)
+            fileOutputStream.close()
+        } catch (e: Exception) {
+            e.printStackTrace()
+        }
     }
 }

--- a/app/src/main/java/com/example/ruok_workers/RevisionFragment.kt
+++ b/app/src/main/java/com/example/ruok_workers/RevisionFragment.kt
@@ -76,9 +76,12 @@ class RevisionFragment : Fragment() {
             val bundle = Bundle()
             val item = ConsultationItem(m_num, 0, "", health, unusual, measure, content, "", 0.0, 0.0, arrayOf(""))
             bundle.putInt("hasConsultation", 1)
+            bundle.putInt("c_num", c_num)
             bundle.putParcelable("consultation_item", item)
+            val photoRevisionFragment = PhotoRevisionFragment()
+            photoRevisionFragment.arguments = bundle
             val DashboardActivity = activity as DashboardActivity
-            DashboardActivity.setFragment(PhotoRevisionFragment())
+            DashboardActivity.setFragment(photoRevisionFragment)
         }
         //건강상태 버튼 클릭시 색변경
         binding.btnRevisionGood.setOnClickListener {


### PR DESCRIPTION
PhotoRevisionFragment.kt 열릴 때
기존 사진 뜨도록 구현하였고,
사진 추가도 가능하도록 구현하였습니다.

사진 삭제는 지원하지 않습니다.

기존 사진의 경우
(1)drawable에서 불러오는 경우,
(2)내부저장소에서 불러오는 경우
두 가지가 있는데 코드로는 모두 성공적으로 구현하였으나
두 코드가 충돌하여 (2)는 주석처리하고 (1)만 남겨놓았습니다.