### PR TITLE
상담내역 작성 시 이름을알수없는 노숙인 선택 안되는 문제 해결

### DIFF
--- a/app/src/main/java/com/example/ruok_workers/HomelessListFragment.kt
+++ b/app/src/main/java/com/example/ruok_workers/HomelessListFragment.kt
@@ -135,7 +135,9 @@ class HomelessListFragment : Fragment() {
 
         //btnNextHomelessList 클릭시 HomelessListFragment에서 LocationAddFragment로 이동
         binding.btnNextHomelessList.setOnClickListener{
-            item.h_num = adapter.h_num
+            if (::adapter.isInitialized) item.h_num = adapter.h_num
+            else item.h_num = 0
+
             val parentActivity = activity as DashboardActivity
             val locationAddFragment = LocationAddFragment()
             bundle.putInt("hasConsultation", hasConsultation)


### PR DESCRIPTION
HomelessListFragment에서 이름을알수없는노숙인 선택 혹은 선택 안 하는 경우에 넘어가지지 않는 오류 해결했습니다!